### PR TITLE
oakary-ats-client to 0.7.25

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: oakary-ats-client
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.7.23
+  version: 0.7.25
 - name: oakary-ats-server
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.5.57


### PR DESCRIPTION
Promote oakary-ats-client to version 0.7.25